### PR TITLE
adapt prometheus.yml params

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -16,24 +16,24 @@ scrape_configs:
 
   - job_name: 'prometheus'
 
-    scrape_interval: 5s
-    scrape_timeout: 10s
+    scrape_interval: 10s
+    scrape_timeout: 5s
 
-    target_groups:
+    static_configs:
       - targets: ['localhost:9090']
 
   - job_name: 'machine-vm'
 
-    scrape_interval: 5s
-    scrape_timeout: 10s
+    scrape_interval: 10s
+    scrape_timeout: 5s
 
-    target_groups:
+    static_configs:
       - targets: ['cadvisor:8080']
 
   - job_name: 'metrics-gateway'
 
-    scrape_interval: 5s
-    scrape_timeout: 10s
+    scrape_interval: 10s
+    scrape_timeout: 5s
 
-    target_groups:
+    static_configs:
       - targets: ['metrics-gateway:9091']


### PR DESCRIPTION
`target_groups` has been replaced by `static_configs`: https://prometheus.io/docs/operating/configuration/#static_config
Also: `scrape_interval` must be greater than `scrape_timeout`.